### PR TITLE
feat(button): submit-activated design updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ In iOS26, the Submit button uses text and border colors that are slightly bright
 
 ```diff
   :root {
-+   --ion-color-primary-brightness-rgb: 130, 255, 255;
-+   --ion-color-secondary-brightness-rgb: [your brightness color];
-+   --ion-color-tertiary-brightness-rgb: [your brightness color];
-+   --ion-color-success-brightness-rgb: [your brightness color];
-+   --ion-color-warning-brightness-rgb: [your brightness color];
-+   --ion-color-danger-brightness-rgb: [your brightness color];
-+   --ion-color-light-brightness-rgb: [your brightness color];
-+   --ion-color-medium-brightness-rgb: [your brightness color];
-+   --ion-color-dark-brightness-rgb: [your brightness color];
++   --ion-color-primary-brightness: #96FEFF;
++   --ion-color-secondary-brightness: [your brightness color];
++   --ion-color-tertiary-brightness: [your brightness color];
++   --ion-color-success-brightness: [your brightness color];
++   --ion-color-warning-brightness: [your brightness color];
++   --ion-color-danger-brightness: [your brightness color];
++   --ion-color-light-brightness: [your brightness color];
++   --ion-color-medium-brightness: [your brightness color];
++   --ion-color-dark-brightness: [your brightness color];
   }
 ```
 

--- a/demo/src/app/docs/docs-page.component.html
+++ b/demo/src/app/docs/docs-page.component.html
@@ -34,10 +34,9 @@
       <div>
         <h3><code>ion-button[fill=solid][type=submit]</code></h3>
         <p>
-          Set color-brightness-rgb as a CSS variable. If using a `primary` button, the following is required. Please set your own color
-          code.
+          Set color-brightness as a CSS variable. If using a `primary` button, the following is required. Please set your own color code.
         </p>
-        <p><code>--ion-color-primary-brightness-rgb: 130, 255, 255;</code></p>
+        <p><code>--ion-color-primary-brightness: #96FEFF;</code></p>
         <p style="display: flex; align-items: center">
           <ion-button type="submit" color="primary" size="default">Submit</ion-button>
           <ion-button type="submit" color="primary" size="default"

--- a/demo/src/theme/variables.scss
+++ b/demo/src/theme/variables.scss
@@ -8,7 +8,7 @@
   --ion-color-primary-contrast-rgb: 255, 255, 255;
   --ion-color-primary-shade: #0279e0;
   --ion-color-primary-tint: #1b95ff;
-  --ion-color-primary-brightness-rgb: 130, 255, 255;
+  --ion-color-primary-brightness: #96feff;
 
   --ion-color-light: #f2f2f7;
   --ion-color-light-rgb: 242, 242, 247;

--- a/src/components/ion-button.scss
+++ b/src/components/ion-button.scss
@@ -183,13 +183,15 @@ $scaledown-large: 0.98;
   &.button-solid[type='submit'] {
     @each $item in primary, secondary, tertiary, success, warning, danger, light, medium, dark {
       &.ion-color-#{$item} {
-        --color: rgb(var(--ion-color-#{$item}-brightness-rgb, var(--ion-color-contrast-rgb)));
-        --color-activated: rgba(var(--ion-color-#{$item}-brightness-rgb), 0.28);
-        --border-color: rgb(var(--ion-color-#{$item}-brightness-rgb, 0 0 0 / 0));
+        --color: var(--ion-color-#{$item}-brightness, var(--ion-color-contrast));
+        --color-activated: var(--ion-color-#{$item}-brightness);
+        --border-color: var(--ion-color-#{$item}-brightness, transparent);
         --border-width: 0.5px;
         --border-style: solid;
       }
     }
+    --background-color: #fff;
+    --background-activated-opacity: 1;
     &:not(.button-has-icon-only):not(.back-button-has-icon-only) {
       &:not(.button-small):not(.button-large) {
         min-height: 44px;
@@ -207,6 +209,7 @@ $scaledown-large: 0.98;
         color: var(--color-activated);
         &::before {
           content: '';
+          z-index: 1;
           width: 100%;
           height: 100%;
           position: absolute;
@@ -214,8 +217,7 @@ $scaledown-large: 0.98;
           left: 0;
           border-radius: inherit;
           pointer-events: none;
-          background: rgba(255, 255, 255, 0.3);
-          backdrop-filter: brightness(120%);
+          backdrop-filter: brightness(144%);
         }
       }
       &.ion-activated.button-has-icon-only,

--- a/src/default-variables.scss
+++ b/src/default-variables.scss
@@ -23,4 +23,12 @@
    * You should replace to '--ios26-content-box-shadow-rgb'.
    */
   --ios26-content-box-shadow-rgb: var(--ios26-color-background-rgb, 255, 255, 255);
+
+  /**
+   * `--ion-color-**-brightness-rgb` is deprecated.
+   * You should replace to '--ion-color-**-brightness'
+   */
+  @each $item in primary, secondary, tertiary, success, warning, danger, light, medium, dark {
+    --ion-color-#{$item}-brightness: rgb(var(--ion-color-#{$item}-brightness-rgb));
+  }
 }


### PR DESCRIPTION
<img width="202" height="87" alt="スクリーンショット 2025-10-10 午後4 20 37" src="https://github.com/user-attachments/assets/73ba7b2b-bc01-4bfd-b541-33d50aa62edb" />

I have made the color scheme closer to iOS26.
Furthermore, by adjusting the brightness, it is no longer necessary to manipulate the transparency. Therefore,

`--ion-color-**-brightness-rgb`

has been deprecated, and

'--ion-color-**-brightness'

is now used.