### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rdlabo/ionic-theme-ios26",
+  "private": false,
   "version": "2.3.2",
   "description": "iOS26 Theme for Ionic Framework",
   "main": "./dist/index.js",


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.